### PR TITLE
removed bug from GetHitTxtFile_H4.C (zeroth strip fired)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*~
+*.png
+*.__afs*
 *.swp
 *.pdf
 callgrind.out.*

--- a/AlignTrackers_Shift.C
+++ b/AlignTrackers_Shift.C
@@ -137,10 +137,10 @@ void  AlignTrackers_Shift( string txtfilename, int RunNumber, double shi_g1xcl, 
 	
         TH1F* h_residual_g1xcl = new TH1F(nameRes1X,"",100,-4,4); h_residual_g1xcl->SetXTitle("Residual [mm]"); h_residual_g1xcl->SetYTitle("Frequency");h_residual_g1xcl->SetLabelSize(0.045,"XY");h_residual_g1xcl->SetTitleSize(0.045,"XY");
         TH1F* h_residual_g1ycl = new TH1F(nameRes1Y,"",100,-4,4); h_residual_g1ycl->SetXTitle("Residual [mm]"); h_residual_g1ycl->SetYTitle("Frequency");h_residual_g1ycl->SetLabelSize(0.045,"XY");h_residual_g1ycl->SetTitleSize(0.045,"XY");
-        TH1F* h_residual_g2xcl = new TH1F(nameRes2X,"",100,-4,4); h_residual_g2xcl->SetXTitle("Residual [mm]"); h_residual_g2xcl->SetYTitle("Frequency");h_residual_g2xcl->SetLabelSize(0.045,"XY");h_residual_g2xcl->SetTitleSize(0.045,"XY");
-        TH1F* h_residual_g2ycl = new TH1F(nameRes2Y,"",100,-4,4); h_residual_g2ycl->SetXTitle("Residual [mm]"); h_residual_g2ycl->SetYTitle("Frequency");h_residual_g2ycl->SetLabelSize(0.045,"XY");h_residual_g2ycl->SetTitleSize(0.045,"XY");
-        TH1F* h_residual_g3xcl = new TH1F(nameRes3X,"",100,-4,4); h_residual_g3xcl->SetXTitle("Residual [mm]"); h_residual_g3xcl->SetYTitle("Frequency");h_residual_g3xcl->SetLabelSize(0.045,"XY");h_residual_g3xcl->SetTitleSize(0.045,"XY");
-        TH1F* h_residual_g3ycl = new TH1F(nameRes3Y,"",100,-4,4); h_residual_g3ycl->SetXTitle("Residual [mm]"); h_residual_g3ycl->SetYTitle("Frequency");h_residual_g3ycl->SetLabelSize(0.045,"XY");h_residual_g3ycl->SetTitleSize(0.045,"XY");
+        TH1F* h_residual_g2xcl = new TH1F(nameRes2X,"",15,-2,2); h_residual_g2xcl->SetXTitle("Residual [mm]"); h_residual_g2xcl->SetYTitle("Frequency");h_residual_g2xcl->SetLabelSize(0.045,"XY");h_residual_g2xcl->SetTitleSize(0.045,"XY");
+        TH1F* h_residual_g2ycl = new TH1F(nameRes2Y,"",15,-2,2); h_residual_g2ycl->SetXTitle("Residual [mm]"); h_residual_g2ycl->SetYTitle("Frequency");h_residual_g2ycl->SetLabelSize(0.045,"XY");h_residual_g2ycl->SetTitleSize(0.045,"XY");
+        TH1F* h_residual_g3xcl = new TH1F(nameRes3X,"",10,-1,1); h_residual_g3xcl->SetXTitle("Residual [mm]"); h_residual_g3xcl->SetYTitle("Frequency");h_residual_g3xcl->SetLabelSize(0.045,"XY");h_residual_g3xcl->SetTitleSize(0.045,"XY");
+        TH1F* h_residual_g3ycl = new TH1F(nameRes3Y,"",10,-1,1); h_residual_g3ycl->SetXTitle("Residual [mm]"); h_residual_g3ycl->SetYTitle("Frequency");h_residual_g3ycl->SetLabelSize(0.045,"XY");h_residual_g3ycl->SetTitleSize(0.045,"XY");
 
 	// Print the mean position of each Detector
 	fout<<shi_g1xcl<<"\t"<<shi_g1ycl<<"\t"<<shi_g2xcl<<"\t"<<shi_g2ycl<<"\t"<<shi_g3xcl<<"\t"<<shi_g3ycl<<"\t"<<endl;

--- a/GetHitTxtFile_H4.C
+++ b/GetHitTxtFile_H4.C
@@ -387,8 +387,8 @@ if (NumCluster_g3x !=0 )
               cout<<"EventNb "<<EventNb<<endl;
               //cout<<"EventNb "<<EventNb<<"\tActual EvtNumber = "<< jentry <<endl;
               //cout<<"EventNb "<<jentry<<endl;
-          file_out<<"EventNb "<<EventNb<<endl;
-//file_out<<"EventNb "<<EventNb<<"\tActual EvtNumber = "<< jentry <<endl;
+	  file_out<<"EventNb "<<EventNb<<endl;
+	  //	  file_out<<"EventNb "<<EventNb<<"\tActual EvtNumber = "<< jentry <<endl;
       
 }
 
@@ -420,6 +420,7 @@ if (NumCluster_g3x !=0 )
                   break;
               for (int chfird=0;chfird<CRC.g1xcl_ngeoch[nch];chfird++)
               {
+		if ( chfird > 0)
                   if((CRC.g1xcl_geoch)[count_ngeoch_occ][chfird] == 0)
                       break;
                   if (verbose)
@@ -463,6 +464,7 @@ int g1x = jentry ;
                   break;
               for (int chfird=0;chfird<CRC.g1ycl_ngeoch[nch];chfird++)
               {
+		if ( chfird > 0)
                   if((CRC.g1ycl_geoch)[count_ngeoch_occ][chfird] == 0)
                       break;
                   if (verbose)
@@ -509,6 +511,7 @@ int g1x = jentry ;
                   break;
               for (int chfird=0;chfird<CRC.g2xcl_ngeoch[nch];chfird++)
               {
+		if ( chfird > 0)
                   if((CRC.g2xcl_geoch)[count_ngeoch_occ][chfird] < 0)
                       break;
                   if (verbose)
@@ -536,6 +539,8 @@ int g1x = jentry ;
           channelFired = 0;
           for(Int_t nch=0;nch<CRC.kMaxg2ycl;nch++)
           {
+	      //if(EventNb == 2318)cout<<"chk this\t"<<nch<<"nggeo\t"<<CRC.g2ycl_ngeoch[nch]<<endl;
+	     // if (nch > 0)
               if (CRC.g2ycl_ngeoch[nch]==0)
                   break;
               channelFired +=CRC.g2ycl_ngeoch[nch];
@@ -547,10 +552,12 @@ int g1x = jentry ;
           count_ngeoch_occ = 0;
           for(Int_t nch=0;nch<CRC.kMaxg2ycl;nch++)
           {
+	    //	      if(EventNb == 2318)cout<<"chk this\t"<<nch<<"nggeo\t"<<CRC.g2ycl_ngeoch[nch]<<endl;
               if (CRC.g2ycl_ngeoch[nch]==0)
                   break;
               for (int chfird=0;chfird<CRC.g2ycl_ngeoch[nch];chfird++)
               {
+	      if ( chfird > 0)
                   if((CRC.g2ycl_geoch)[count_ngeoch_occ][chfird] == 0)
                       break;
                   if (verbose)
@@ -930,7 +937,7 @@ int g1x = jentry ;
     count_ngeoch_occ = 0;
     for(Int_t nch=0;nch<CRC.kMaxGE11_IV_GIF;nch++)
     {
-	if (CRC.GE11_IV_GIF_ngeoch[nch]==0)
+	if (CRC.GE11_IV_GIF_ngeoch[nch]== 0)
 	break;
     for (int chfird=0;chfird<CRC.GE11_IV_GIF_ngeoch[nch];chfird++)
     {


### PR DESCRIPTION
If strip fired is at zeroth position then it should be taken as a valid hit and scanning should continue. Earlier if strip fired was zero (position of fired strip) code was exiting. But it can happen only strip zero is fired so now it has been accounted for in the code.
